### PR TITLE
Make GeoHash length a const generic and derive `MaxEncodedLen` for it.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ documentation = "https://docs.rs/geohash/"
 edition = "2018"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive", "max-encoded-len"] }
 fixed = { package = "substrate-fixed", tag = "v0.5.7", default-features = false, git = "https://github.com/encointer/substrate-fixed" }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2018"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive", "max-encoded-len"] }
-fixed = { package = "substrate-fixed", tag = "v0.5.7", default-features = false, git = "https://github.com/encointer/substrate-fixed" }
+fixed = { package = "substrate-fixed", tag = "v0.5.8", default-features = false, git = "https://github.com/encointer/substrate-fixed" }
 scale-info = { version = "1.0.0", default-features = false, features = ["derive"] }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -38,7 +38,7 @@ impl<const LEN: usize> TryFrom<&[u8]> for GeoHash<LEN> {
     type Error = GeohashError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        // `try_from` is only successful if the input is a valid base 32 encoded geo hash.
+        // `try_from` is only successful if the input is a valid base 32 encoded geo hash of length `LEN`
 
         if value.len() != LEN {
             return Err(GeohashError::InvalidLen);

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -54,3 +54,16 @@ impl<const LEN: usize> TryFrom<&[u8]> for GeoHash<LEN> {
         Ok(GeoHash(arr))
     }
 }
+
+impl<const LEN: usize> Into<[u8; LEN]> for GeoHash<LEN> {
+    fn into(self) -> [u8; LEN] {
+        self.0
+    }
+}
+
+impl<const LEN: usize> Into<String> for GeoHash<LEN> {
+    fn into(self) -> String {
+        String::from_utf8(self.0.to_vec())
+            .expect("Geohash can only be constructed from a subset of utf8-strings; qed")
+    }
+}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,56 @@
+use crate::{hash_value_of_char, GeoHash, GeohashError};
+use alloc::string::String;
+use core::{convert::TryFrom, ops::Deref};
+
+impl<const LEN: usize> Deref for GeoHash<LEN> {
+    type Target = [u8; LEN];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<const LEN: usize> TryFrom<&str> for GeoHash<LEN> {
+    type Error = GeohashError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        TryFrom::<&[u8]>::try_from(value.as_bytes())
+    }
+}
+
+impl<const LEN: usize> TryFrom<String> for GeoHash<LEN> {
+    type Error = GeohashError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        TryFrom::<&[u8]>::try_from(value.as_bytes())
+    }
+}
+
+impl<const LEN: usize> TryFrom<[u8; LEN]> for GeoHash<LEN> {
+    type Error = GeohashError;
+
+    fn try_from(value: [u8; LEN]) -> Result<Self, Self::Error> {
+        TryFrom::<&[u8]>::try_from(&value[..])
+    }
+}
+
+impl<const LEN: usize> TryFrom<&[u8]> for GeoHash<LEN> {
+    type Error = GeohashError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        // `try_from` is only successful if the input is a valid base 32 encoded geo hash.
+
+        if value.len() != LEN {
+            return Err(GeohashError::InvalidLen);
+        }
+
+        for c in value.iter() {
+            let _ = hash_value_of_char(*c as char)?;
+        }
+
+        let mut arr = [0u8; LEN];
+        arr.clone_from_slice(value);
+
+        Ok(GeoHash(arr))
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,5 +2,6 @@ use fixed::types::I64F64;
 #[derive(Debug)]
 pub enum GeohashError {
     InvalidHashCharacter(char),
+    InvalidLen,
     InvalidCoordinateRange(I64F64, I64F64),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,14 @@ impl<const LEN: usize> TryFrom<&str> for GeoHash<LEN> {
     }
 }
 
+impl<const LEN: usize> TryFrom<[u8; LEN]> for GeoHash<LEN> {
+    type Error = GeohashError;
+
+    fn try_from(value: [u8; LEN]) -> Result<Self, Self::Error> {
+        TryFrom::<&[u8]>::try_from(&value[..])
+    }
+}
+
 impl<const LEN: usize> TryFrom<&[u8]> for GeoHash<LEN> {
     type Error = GeohashError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,17 +74,26 @@ impl<const LEN: usize> TryFrom<&str> for GeoHash<LEN> {
     type Error = GeohashError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
+        TryFrom::<&[u8]>::try_from(value.as_bytes())
+    }
+}
+
+impl<const LEN: usize> TryFrom<&[u8]> for GeoHash<LEN> {
+    type Error = GeohashError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        // `try_from` is only successful if the input is a valid base 32 encoded geo hash.
+
         if value.len() != LEN {
             return Err(GeohashError::InvalidLen);
         }
-        // `try_from` is only successful if the input is a valid base 32 encoded geo hash.
 
-        for c in value.as_bytes().iter() {
+        for c in value.iter() {
             let _ = hash_value_of_char(*c as char)?;
         }
 
         let mut arr = [0u8; LEN];
-        arr.clone_from_slice(value.as_bytes());
+        arr.clone_from_slice(value);
 
         Ok(GeoHash(arr))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,10 +72,10 @@ static BASE32_CODES: &[char] = &[
 pub struct GeoHash<const LEN: usize>(pub [u8; LEN]);
 
 impl<const LEN: usize> Deref for GeoHash<LEN> {
-    type Target = [u8];
+    type Target = [u8; LEN];
 
     fn deref(&self) -> &Self::Target {
-        &self.0[..]
+        &self.0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ static BASE32_CODES: &[char] = &[
     scale_info::TypeInfo,
     MaxEncodedLen,
 )]
-pub struct GeoHash<const LEN: usize>(pub [u8; LEN]);
+pub struct GeoHash<const LEN: usize>([u8; LEN]);
 
 impl<const LEN: usize> GeoHash<LEN> {
     /// Internal function to encode a coordinate to a geohash with length `LEN`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,10 @@
 //!   let lat = I64F64::from_num(37.8324f64);
 //!
 //!   // decode a geohash
-//!   let (lon, lat, _, _) = GeoHash::try_from("ww8p1r4t8")?.try_as_coordinates()?;
+//!   let (lon, lat, _, _) = GeoHash::<9>::try_from("ww8p1r4t8")?.try_as_coordinates()?;
 //!
 //!   // find a neighboring hash
-//!   let sw = GeoHash::try_from("ww8p1r4t8")?.neighbor(Direction::SW)?;
+//!   let sw = GeoHash::<9>::try_from("ww8p1r4t8")?.neighbor(Direction::SW)?;
 //!
 //!   Ok(())
 //! }
@@ -120,8 +120,8 @@ impl<const LEN: usize> GeoHash<LEN> {
     /// use geohash::GeoHash;
     /// let lon = I64F64::from_num(-120.6623);
     /// let lat = I64F64::from_num(35.3003);
-    /// let geohash_string = GeoHash::try_from_params(lat, lon).expect("Invalid coordinate");
-    /// assert_eq!(geohash_string, GeoHash::try_from("9q60y").unwrap());
+    /// let geohash_string = GeoHash::<5>::try_from_params(lat, lon).expect("Invalid coordinate");
+    /// assert_eq!(geohash_string, GeoHash::<5>::try_from("9q60y").unwrap());
     /// ```
     ///
     /// Encoding a coordinate to a length ten geohash:
@@ -132,9 +132,9 @@ impl<const LEN: usize> GeoHash<LEN> {
     /// use geohash::GeoHash;
     /// let lon = I64F64::from_num(-120.6623);
     /// let lat = I64F64::from_num(35.3003);
-    /// let geohash_string = GeoHash::try_from_params(lat, lon).expect("Invalid coordinate");
+    /// let geohash_string = GeoHash::<10>::try_from_params(lat, lon).expect("Invalid coordinate");
     ///
-    /// assert_eq!(geohash_string, GeoHash::try_from("9q60y60rhs").unwrap());
+    /// assert_eq!(geohash_string, GeoHash::<10>::try_from("9q60y60rhs").unwrap());
     /// ```
     pub fn try_from_params(lat: I64F64, lon: I64F64) -> Result<GeoHash<LEN>, GeohashError> {
         let mut out = [0u8; LEN];
@@ -254,7 +254,7 @@ impl<const LEN: usize> GeoHash<LEN> {
     /// use std::convert::TryFrom;
     /// use fixed::types::I64F64;
     /// use geohash::GeoHash;
-    /// let geohash_str = GeoHash::try_from("9q60y").unwrap();
+    /// let geohash_str = GeoHash::<5>::try_from("9q60y").unwrap();
     /// let decoded = geohash_str.try_as_coordinates().expect("Invalid hash string");
     /// assert_eq!(
     ///     decoded,
@@ -273,7 +273,7 @@ impl<const LEN: usize> GeoHash<LEN> {
     /// use std::convert::TryFrom;
     /// use fixed::types::I64F64;
     /// use geohash::GeoHash;
-    /// let geohash_str = GeoHash::try_from("9q60y60rhs").unwrap();
+    /// let geohash_str = GeoHash::<10>::try_from("9q60y60rhs").unwrap();
     /// let decoded = geohash_str.try_as_coordinates().expect("Invalid hash string");
     /// assert_eq!(
     ///     decoded,
@@ -315,21 +315,22 @@ impl<const LEN: usize> GeoHash<LEN> {
     /// ```
     /// use std::convert::TryFrom;
     /// use geohash::GeoHash;
-    /// let geohash_str = GeoHash::try_from("9q60y60rhs").unwrap();
+    /// type Geo10 = GeoHash<10>;
+    /// let geohash_str = Geo10::try_from("9q60y60rhs").unwrap();
     ///
     /// let neighbors = geohash_str.neighbors().expect("Invalid hash string");
     ///
     /// assert_eq!(
     ///     neighbors,
     ///     geohash::Neighbors {
-    ///         n: GeoHash::try_from("9q60y60rht").unwrap(),
-    ///         ne: GeoHash::try_from("9q60y60rhv").unwrap(),
-    ///         e: GeoHash::try_from("9q60y60rhu").unwrap(),
-    ///         se: GeoHash::try_from("9q60y60rhg").unwrap(),
-    ///         s: GeoHash::try_from("9q60y60rhe").unwrap(),
-    ///         sw: GeoHash::try_from("9q60y60rh7").unwrap(),
-    ///         w: GeoHash::try_from("9q60y60rhk").unwrap(),
-    ///         nw: GeoHash::try_from("9q60y60rhm").unwrap(),
+    ///         n: Geo10::try_from("9q60y60rht").unwrap(),
+    ///         ne: Geo10::try_from("9q60y60rhv").unwrap(),
+    ///         e: Geo10::try_from("9q60y60rhu").unwrap(),
+    ///         se: Geo10::try_from("9q60y60rhg").unwrap(),
+    ///         s: Geo10::try_from("9q60y60rhe").unwrap(),
+    ///         sw: Geo10::try_from("9q60y60rh7").unwrap(),
+    ///         w: Geo10::try_from("9q60y60rhk").unwrap(),
+    ///         nw: Geo10::try_from("9q60y60rhm").unwrap(),
     ///     }
     /// );
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ extern crate alloc;
 use ::core::ops::Deref;
 use alloc::vec::Vec;
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use fixed::types::I64F64;
 
 pub use crate::error::GeohashError;
@@ -59,7 +59,7 @@ static BASE32_CODES: &[char] = &[
     'm', 'n', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
 ];
 
-#[derive(Encode, Decode, Eq, PartialEq, Clone, Debug, Ord, PartialOrd, scale_info::TypeInfo)]
+#[derive(Encode, Decode, Eq, PartialEq, Clone, Debug, Ord, PartialOrd, scale_info::TypeInfo, MaxEncodedLen)]
 pub struct GeoHash(pub Vec<u8>);
 
 impl Deref for GeoHash {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,7 @@
 
 extern crate alloc;
 
-use ::core::ops::Deref;
 use codec::{Decode, Encode, MaxEncodedLen};
-use core::convert::TryFrom;
 use fixed::types::I64F64;
 
 pub use crate::error::GeohashError;
@@ -70,51 +68,6 @@ static BASE32_CODES: &[char] = &[
     MaxEncodedLen,
 )]
 pub struct GeoHash<const LEN: usize>(pub [u8; LEN]);
-
-impl<const LEN: usize> Deref for GeoHash<LEN> {
-    type Target = [u8; LEN];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<const LEN: usize> TryFrom<&str> for GeoHash<LEN> {
-    type Error = GeohashError;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        TryFrom::<&[u8]>::try_from(value.as_bytes())
-    }
-}
-
-impl<const LEN: usize> TryFrom<[u8; LEN]> for GeoHash<LEN> {
-    type Error = GeohashError;
-
-    fn try_from(value: [u8; LEN]) -> Result<Self, Self::Error> {
-        TryFrom::<&[u8]>::try_from(&value[..])
-    }
-}
-
-impl<const LEN: usize> TryFrom<&[u8]> for GeoHash<LEN> {
-    type Error = GeohashError;
-
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        // `try_from` is only successful if the input is a valid base 32 encoded geo hash.
-
-        if value.len() != LEN {
-            return Err(GeohashError::InvalidLen);
-        }
-
-        for c in value.iter() {
-            let _ = hash_value_of_char(*c as char)?;
-        }
-
-        let mut arr = [0u8; LEN];
-        arr.clone_from_slice(value);
-
-        Ok(GeoHash(arr))
-    }
-}
 
 impl<const LEN: usize> GeoHash<LEN> {
     /// Internal function to encode a coordinate to a geohash with length `LEN`.
@@ -373,5 +326,6 @@ fn hash_value_of_char(c: char) -> Result<usize, GeohashError> {
     Err(GeohashError::InvalidHashCharacter(c))
 }
 
+mod convert;
 mod error;
 mod neighbors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,22 +34,20 @@
 extern crate alloc;
 
 use ::core::ops::Deref;
-use core::convert::TryFrom;
 use codec::{Decode, Encode, MaxEncodedLen};
+use core::convert::TryFrom;
 use fixed::types::I64F64;
 
 pub use crate::error::GeohashError;
 pub use crate::neighbors::{Direction, Neighbors};
 
 #[derive(Debug)]
-struct Coordinate
-{
+struct Coordinate {
     pub lon: I64F64,
     pub lat: I64F64,
 }
 
-struct Rectangle
-{
+struct Rectangle {
     min: Coordinate,
     max: Coordinate,
 }
@@ -59,7 +57,18 @@ static BASE32_CODES: &[char] = &[
     'm', 'n', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
 ];
 
-#[derive(Encode, Decode, Eq, PartialEq, Clone, Debug, Ord, PartialOrd, scale_info::TypeInfo, MaxEncodedLen)]
+#[derive(
+    Encode,
+    Decode,
+    Eq,
+    PartialEq,
+    Clone,
+    Debug,
+    Ord,
+    PartialOrd,
+    scale_info::TypeInfo,
+    MaxEncodedLen,
+)]
 pub struct GeoHash<const LEN: usize>(pub [u8; LEN]);
 
 impl<const LEN: usize> Deref for GeoHash<LEN> {
@@ -337,8 +346,8 @@ impl<const LEN: usize> GeoHash<LEN> {
     pub fn neighbors(&self) -> Result<Neighbors<LEN>, GeohashError> {
         Ok(Neighbors {
             sw: self.neighbor(Direction::SW)?,
-            s: self.neighbor( Direction::S)?,
-            se: self.neighbor( Direction::SE)?,
+            s: self.neighbor(Direction::S)?,
+            se: self.neighbor(Direction::SE)?,
             w: self.neighbor(Direction::W)?,
             e: self.neighbor(Direction::E)?,
             nw: self.neighbor(Direction::NW)?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ impl<const LEN: usize> GeoHash<LEN> {
         }
 
         let two = I64F64::from_num(2);
-        for i in 0..out.len() {
+        for byte in &mut out {
             for _ in 0..5 {
                 if bits_total % 2 == 0 {
                     let mid = (max_lon + min_lon) / two;
@@ -138,7 +138,7 @@ impl<const LEN: usize> GeoHash<LEN> {
             }
 
             let code: char = BASE32_CODES[hash_value];
-            out[i] = code as u8;
+            *byte = code as u8;
             hash_value = 0;
         }
         Ok(GeoHash(out))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,9 @@ impl<const LEN: usize> TryFrom<&str> for GeoHash<LEN> {
     type Error = GeohashError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
+        if value.len() != LEN {
+            return Err(GeohashError::InvalidLen);
+        }
         // `try_from` is only successful if the input is a valid base 32 encoded geo hash.
 
         for c in value.as_bytes().iter() {
@@ -81,7 +84,6 @@ impl<const LEN: usize> TryFrom<&str> for GeoHash<LEN> {
         }
 
         let mut arr = [0u8; LEN];
-        // if all values are a valid hash, we can be sure that one character is only one byte
         arr.clone_from_slice(value.as_bytes());
 
         Ok(GeoHash(arr))

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -19,7 +19,7 @@ pub enum Direction {
     N,
     /// North-east
     NE,
-    /// Eeast
+    /// East
     E,
     /// South-east
     SE,

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -2,15 +2,15 @@ use fixed::types::I64F64;
 use crate::GeoHash;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Neighbors {
-    pub sw: GeoHash,
-    pub s: GeoHash,
-    pub se: GeoHash,
-    pub w: GeoHash,
-    pub e: GeoHash,
-    pub nw: GeoHash,
-    pub n: GeoHash,
-    pub ne: GeoHash,
+pub struct Neighbors<const T: usize> {
+    pub sw: GeoHash<T>,
+    pub s: GeoHash<T>,
+    pub se: GeoHash<T>,
+    pub w: GeoHash<T>,
+    pub e: GeoHash<T>,
+    pub nw: GeoHash<T>,
+    pub n: GeoHash<T>,
+    pub ne: GeoHash<T>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -1,5 +1,5 @@
-use fixed::types::I64F64;
 use crate::GeoHash;
+use fixed::types::I64F64;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Neighbors<const T: usize> {

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -2,15 +2,15 @@ use crate::GeoHash;
 use fixed::types::I64F64;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct Neighbors<const T: usize> {
-    pub sw: GeoHash<T>,
-    pub s: GeoHash<T>,
-    pub se: GeoHash<T>,
-    pub w: GeoHash<T>,
-    pub e: GeoHash<T>,
-    pub nw: GeoHash<T>,
-    pub n: GeoHash<T>,
-    pub ne: GeoHash<T>,
+pub struct Neighbors<const LEN: usize> {
+    pub sw: GeoHash<LEN>,
+    pub s: GeoHash<LEN>,
+    pub se: GeoHash<LEN>,
+    pub w: GeoHash<LEN>,
+    pub e: GeoHash<LEN>,
+    pub nw: GeoHash<LEN>,
+    pub n: GeoHash<LEN>,
+    pub ne: GeoHash<LEN>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/tests/base.rs
+++ b/tests/base.rs
@@ -7,90 +7,90 @@ use std::convert::TryFrom;
 
 #[test]
 fn test_encode() {
-	let lon = I64F64::from_num(112.5584);
-	let lat = I64F64::from_num(37.8324f64);
-	assert_eq!(
-		GeoHash::<9>::try_from_params(lat, lon).unwrap(),
-		GeoHash::<9>::try_from("ww8p1r4t8").unwrap()
-	);
+    let lon = I64F64::from_num(112.5584);
+    let lat = I64F64::from_num(37.8324f64);
+    assert_eq!(
+        GeoHash::<9>::try_from_params(lat, lon).unwrap(),
+        GeoHash::<9>::try_from("ww8p1r4t8").unwrap()
+    );
 
-	let lon = I64F64::from_num(117);
-	let lat = I64F64::from_num(32);
-	assert_eq!(
-		GeoHash::<3>::try_from_params(lat, lon).unwrap(),
-		GeoHash::<3>::try_from("wte").unwrap()
-	);
+    let lon = I64F64::from_num(117);
+    let lat = I64F64::from_num(32);
+    assert_eq!(
+        GeoHash::<3>::try_from_params(lat, lon).unwrap(),
+        GeoHash::<3>::try_from("wte").unwrap()
+    );
 
-	let lon = I64F64::from_num(190);
-	let lat = I64F64::from_num(-100);
-	assert!(GeoHash::<9>::try_from_params(lat, lon).is_err());
+    let lon = I64F64::from_num(190);
+    let lat = I64F64::from_num(-100);
+    assert!(GeoHash::<9>::try_from_params(lat, lon).is_err());
 }
 
 fn compare_within(a: I64F64, b: I64F64, diff: I64F64) {
-	if !((a - b).abs() < diff) {
-		panic!("{:?} and {:?} should be within {:?}", a, b, diff);
-	}
+    if !((a - b).abs() < diff) {
+        panic!("{:?} and {:?} should be within {:?}", a, b, diff);
+    }
 }
 
 fn compare_decode<const LEN: usize>(
-	gh: GeoHash<LEN>,
-	exp_lon: I64F64,
-	exp_lat: I64F64,
-	exp_lon_err: I64F64,
-	exp_lat_err: I64F64,
+    gh: GeoHash<LEN>,
+    exp_lon: I64F64,
+    exp_lat: I64F64,
+    exp_lon_err: I64F64,
+    exp_lat_err: I64F64,
 ) {
-	let (lon, lat, lon_err, lat_err) = gh.try_as_coordinates().unwrap();
-	let diff = I64F64::from_num(1e-5);
-	compare_within(lon_err, exp_lon_err, diff);
-	compare_within(lat_err, exp_lat_err, diff);
-	compare_within(lon, exp_lon, diff);
-	compare_within(lat, exp_lat, diff);
+    let (lon, lat, lon_err, lat_err) = gh.try_as_coordinates().unwrap();
+    let diff = I64F64::from_num(1e-5);
+    compare_within(lon_err, exp_lon_err, diff);
+    compare_within(lat_err, exp_lat_err, diff);
+    compare_within(lon, exp_lon, diff);
+    compare_within(lat, exp_lat, diff);
 }
 
 #[test]
 fn test_decode() {
-	compare_decode(
-		GeoHash::<9>::try_from("ww8p1r4t8").unwrap(),
-		I64F64::from_num(112.558386),
-		I64F64::from_num(37.832386),
-		I64F64::from_num(0.000021457),
-		I64F64::from_num(0.000021457),
-	);
-	compare_decode(
-		GeoHash::<4>::try_from("9g3q").unwrap(),
-		I64F64::from_num(-99.31640625),
-		I64F64::from_num(19.423828125),
-		I64F64::from_num(0.175781250),
-		I64F64::from_num(0.087890625),
-	);
+    compare_decode(
+        GeoHash::<9>::try_from("ww8p1r4t8").unwrap(),
+        I64F64::from_num(112.558386),
+        I64F64::from_num(37.832386),
+        I64F64::from_num(0.000021457),
+        I64F64::from_num(0.000021457),
+    );
+    compare_decode(
+        GeoHash::<4>::try_from("9g3q").unwrap(),
+        I64F64::from_num(-99.31640625),
+        I64F64::from_num(19.423828125),
+        I64F64::from_num(0.175781250),
+        I64F64::from_num(0.087890625),
+    );
 
-	assert!(GeoHash::<4>::try_from("abcd").is_err());
+    assert!(GeoHash::<4>::try_from("abcd").is_err());
 }
 
 #[test]
 fn test_neighbor() {
-	type Geo9 = GeoHash<9>;
-	let ns = Geo9::try_from("ww8p1r4t8").unwrap().neighbors().unwrap();
-	assert_eq!(ns.sw, Geo9::try_from("ww8p1r4mr").unwrap());
-	assert_eq!(ns.s, Geo9::try_from("ww8p1r4t2").unwrap());
-	assert_eq!(ns.se, Geo9::try_from("ww8p1r4t3").unwrap());
-	assert_eq!(ns.w, Geo9::try_from("ww8p1r4mx").unwrap());
-	assert_eq!(ns.e, Geo9::try_from("ww8p1r4t9").unwrap());
-	assert_eq!(ns.nw, Geo9::try_from("ww8p1r4mz").unwrap());
-	assert_eq!(ns.n, Geo9::try_from("ww8p1r4tb").unwrap());
-	assert_eq!(ns.ne, Geo9::try_from("ww8p1r4tc").unwrap());
+    type Geo9 = GeoHash<9>;
+    let ns = Geo9::try_from("ww8p1r4t8").unwrap().neighbors().unwrap();
+    assert_eq!(ns.sw, Geo9::try_from("ww8p1r4mr").unwrap());
+    assert_eq!(ns.s, Geo9::try_from("ww8p1r4t2").unwrap());
+    assert_eq!(ns.se, Geo9::try_from("ww8p1r4t3").unwrap());
+    assert_eq!(ns.w, Geo9::try_from("ww8p1r4mx").unwrap());
+    assert_eq!(ns.e, Geo9::try_from("ww8p1r4t9").unwrap());
+    assert_eq!(ns.nw, Geo9::try_from("ww8p1r4mz").unwrap());
+    assert_eq!(ns.n, Geo9::try_from("ww8p1r4tb").unwrap());
+    assert_eq!(ns.ne, Geo9::try_from("ww8p1r4tc").unwrap());
 }
 
 #[test]
 fn test_neighbor_wide() {
-	type Geo4 = GeoHash<4>;
-	let ns = Geo4::try_from("9g3m").unwrap().neighbors().unwrap();
-	assert_eq!(ns.sw, Geo4::try_from("9g3h").unwrap());
-	assert_eq!(ns.s, Geo4::try_from("9g3k").unwrap());
-	assert_eq!(ns.se, Geo4::try_from("9g3s").unwrap());
-	assert_eq!(ns.w, Geo4::try_from("9g3j").unwrap());
-	assert_eq!(ns.e, Geo4::try_from("9g3t").unwrap());
-	assert_eq!(ns.nw, Geo4::try_from("9g3n").unwrap());
-	assert_eq!(ns.n, Geo4::try_from("9g3q").unwrap());
-	assert_eq!(ns.ne, Geo4::try_from("9g3w").unwrap());
+    type Geo4 = GeoHash<4>;
+    let ns = Geo4::try_from("9g3m").unwrap().neighbors().unwrap();
+    assert_eq!(ns.sw, Geo4::try_from("9g3h").unwrap());
+    assert_eq!(ns.s, Geo4::try_from("9g3k").unwrap());
+    assert_eq!(ns.se, Geo4::try_from("9g3s").unwrap());
+    assert_eq!(ns.w, Geo4::try_from("9g3j").unwrap());
+    assert_eq!(ns.e, Geo4::try_from("9g3t").unwrap());
+    assert_eq!(ns.nw, Geo4::try_from("9g3n").unwrap());
+    assert_eq!(ns.n, Geo4::try_from("9g3q").unwrap());
+    assert_eq!(ns.ne, Geo4::try_from("9g3w").unwrap());
 }

--- a/tests/base.rs
+++ b/tests/base.rs
@@ -1,70 +1,96 @@
-extern crate geohash;
 extern crate alloc;
+extern crate geohash;
 
 use fixed::types::I64F64;
 use geohash::GeoHash;
+use std::convert::TryFrom;
 
 #[test]
 fn test_encode() {
-    let lon = I64F64::from_num(112.5584);
-    let lat = I64F64::from_num(37.8324f64);
-    assert_eq!(GeoHash::try_from_params(lat, lon, 9usize).unwrap(), GeoHash::from("ww8p1r4t8"));
+	let lon = I64F64::from_num(112.5584);
+	let lat = I64F64::from_num(37.8324f64);
+	assert_eq!(
+		GeoHash::<9>::try_from_params(lat, lon).unwrap(),
+		GeoHash::<9>::try_from("ww8p1r4t8").unwrap()
+	);
 
-    let lon = I64F64::from_num(117);
-    let lat = I64F64::from_num(32);
-    assert_eq!(GeoHash::try_from_params(lat, lon, 3usize).unwrap(), GeoHash::from("wte"));
+	let lon = I64F64::from_num(117);
+	let lat = I64F64::from_num(32);
+	assert_eq!(
+		GeoHash::<3>::try_from_params(lat, lon).unwrap(),
+		GeoHash::<3>::try_from("wte").unwrap()
+	);
 
-    let lon = I64F64::from_num(190);
-    let lat = I64F64::from_num(-100);
-    assert!(GeoHash::try_from_params(lat, lon, 3usize).is_err());
+	let lon = I64F64::from_num(190);
+	let lat = I64F64::from_num(-100);
+	assert!(GeoHash::<9>::try_from_params(lat, lon).is_err());
 }
 
 fn compare_within(a: I64F64, b: I64F64, diff: I64F64) {
-    assert!(
-        (a - b).abs() < diff,
-        format!("{:?} and {:?} should be within {:?}", a, b, diff)
-    );
+	if !((a - b).abs() < diff) {
+		panic!("{:?} and {:?} should be within {:?}", a, b, diff);
+	}
 }
 
-fn compare_decode(gh: GeoHash, exp_lon: I64F64, exp_lat: I64F64, exp_lon_err: I64F64, exp_lat_err: I64F64) {
-    let (lon, lat, lon_err, lat_err) = gh.try_as_coordinates().unwrap();
-    let diff = I64F64::from_num(1e-5);
-    compare_within(lon_err, exp_lon_err, diff);
-    compare_within(lat_err, exp_lat_err, diff);
-    compare_within(lon, exp_lon, diff);
-    compare_within(lat, exp_lat, diff);
+fn compare_decode<const LEN: usize>(
+	gh: GeoHash<LEN>,
+	exp_lon: I64F64,
+	exp_lat: I64F64,
+	exp_lon_err: I64F64,
+	exp_lat_err: I64F64,
+) {
+	let (lon, lat, lon_err, lat_err) = gh.try_as_coordinates().unwrap();
+	let diff = I64F64::from_num(1e-5);
+	compare_within(lon_err, exp_lon_err, diff);
+	compare_within(lat_err, exp_lat_err, diff);
+	compare_within(lon, exp_lon, diff);
+	compare_within(lat, exp_lat, diff);
 }
 
 #[test]
 fn test_decode() {
-    compare_decode(GeoHash::from("ww8p1r4t8"), I64F64::from_num(112.558386), I64F64::from_num(37.832386), I64F64::from_num(0.000021457), I64F64::from_num(0.000021457));
-    compare_decode(GeoHash::from("9g3q"), I64F64::from_num(-99.31640625), I64F64::from_num(19.423828125), I64F64::from_num(0.175781250), I64F64::from_num(0.087890625));
+	compare_decode(
+		GeoHash::<9>::try_from("ww8p1r4t8").unwrap(),
+		I64F64::from_num(112.558386),
+		I64F64::from_num(37.832386),
+		I64F64::from_num(0.000021457),
+		I64F64::from_num(0.000021457),
+	);
+	compare_decode(
+		GeoHash::<4>::try_from("9g3q").unwrap(),
+		I64F64::from_num(-99.31640625),
+		I64F64::from_num(19.423828125),
+		I64F64::from_num(0.175781250),
+		I64F64::from_num(0.087890625),
+	);
 
-    assert!(GeoHash::from("abcd").try_as_coordinates().is_err());
+	assert!(GeoHash::<4>::try_from("abcd").is_err());
 }
 
 #[test]
 fn test_neighbor() {
-    let ns = &GeoHash::from("ww8p1r4t8").neighbors().unwrap();
-    assert_eq!(ns.sw, GeoHash::from("ww8p1r4mr"));
-    assert_eq!(ns.s, GeoHash::from("ww8p1r4t2"));
-    assert_eq!(ns.se, GeoHash::from("ww8p1r4t3"));
-    assert_eq!(ns.w, GeoHash::from("ww8p1r4mx"));
-    assert_eq!(ns.e, GeoHash::from("ww8p1r4t9"));
-    assert_eq!(ns.nw, GeoHash::from("ww8p1r4mz"));
-    assert_eq!(ns.n, GeoHash::from("ww8p1r4tb"));
-    assert_eq!(ns.ne, GeoHash::from("ww8p1r4tc"));
+	type Geo9 = GeoHash<9>;
+	let ns = Geo9::try_from("ww8p1r4t8").unwrap().neighbors().unwrap();
+	assert_eq!(ns.sw, Geo9::try_from("ww8p1r4mr").unwrap());
+	assert_eq!(ns.s, Geo9::try_from("ww8p1r4t2").unwrap());
+	assert_eq!(ns.se, Geo9::try_from("ww8p1r4t3").unwrap());
+	assert_eq!(ns.w, Geo9::try_from("ww8p1r4mx").unwrap());
+	assert_eq!(ns.e, Geo9::try_from("ww8p1r4t9").unwrap());
+	assert_eq!(ns.nw, Geo9::try_from("ww8p1r4mz").unwrap());
+	assert_eq!(ns.n, Geo9::try_from("ww8p1r4tb").unwrap());
+	assert_eq!(ns.ne, Geo9::try_from("ww8p1r4tc").unwrap());
 }
 
 #[test]
 fn test_neighbor_wide() {
-    let ns = &GeoHash::from("9g3m").neighbors().unwrap();
-    assert_eq!(ns.sw, GeoHash::from("9g3h"));
-    assert_eq!(ns.s, GeoHash::from("9g3k"));
-    assert_eq!(ns.se, GeoHash::from("9g3s"));
-    assert_eq!(ns.w, GeoHash::from("9g3j"));
-    assert_eq!(ns.e, GeoHash::from("9g3t"));
-    assert_eq!(ns.nw, GeoHash::from("9g3n"));
-    assert_eq!(ns.n, GeoHash::from("9g3q"));
-    assert_eq!(ns.ne, GeoHash::from("9g3w"));
+	type Geo4 = GeoHash<4>;
+	let ns = Geo4::try_from("9g3m").unwrap().neighbors().unwrap();
+	assert_eq!(ns.sw, Geo4::try_from("9g3h").unwrap());
+	assert_eq!(ns.s, Geo4::try_from("9g3k").unwrap());
+	assert_eq!(ns.se, Geo4::try_from("9g3s").unwrap());
+	assert_eq!(ns.w, Geo4::try_from("9g3j").unwrap());
+	assert_eq!(ns.e, Geo4::try_from("9g3t").unwrap());
+	assert_eq!(ns.nw, Geo4::try_from("9g3n").unwrap());
+	assert_eq!(ns.n, Geo4::try_from("9g3q").unwrap());
+	assert_eq!(ns.ne, Geo4::try_from("9g3w").unwrap());
 }


### PR DESCRIPTION
* See https://github.com/encointer/pallets/issues/132. This means we can't use `Vec<u8>` as the field for the `GeoHash`.

I chose to go for a const generic approach as it is more efficient than a `bounded_vec` approach. Further, the bounded_vec approach would require checking each operation if it lets the vec grow beyond its size.

Other changes:
* GeoHash field is private now: Implies that every GeoHash object does now contain a valid geo hash, as all construction helpers would fail upon construction.
* Implemented some more conversion traits.